### PR TITLE
Merge order

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,20 +12,15 @@ pip install pdf-suite
 ### Merge
 Merges multiple PDF files into one.
 
-#### In order
-To merge your files in a specific order, specify your files in the order you want in `ORDER` array in `merger.py` file.
-
-```python
-ORDER = [
-    'file1.pdf',
-    'file2.pdf',
-    'file3.pdf',
-]
-```
-
-#### Run
 ```bash
 pdf_suite merge -i input -o output
+```
+
+#### In order
+To merge your files in a specific order, you need to pass the order you want to `--order` option.
+
+```bash
+pdf_suite merge -i input -o output --order file1,file2,file3
 ```
 
 #### Output
@@ -34,7 +29,6 @@ An `ouput.pdf` file will be generated in `/output` directory.
 ### PDF to Images
 Extract images from your PDF file.
 
-#### Run
 ```bash
 pdf_suite pdf2img --input file.pdf --output images_directory
 ```

--- a/pdf_suite/command_line/command_line.py
+++ b/pdf_suite/command_line/command_line.py
@@ -11,13 +11,14 @@ class CommandLine:
     @app.command()
     def merge(
         input: str = typer.Option('input', "--input", "-i", help="Where all your files to merge reside."),
-        output: str = typer.Option('output', "--output", "-o", help="Where you gonna find the generated pdf.")
+        output: str = typer.Option('output', "--output", "-o", help="Where you gonna find the generated pdf."),
+        order: str = typer.Option(None, "--order", help="Order of your pdf files."),
     ):
-        Merger().merge(input, output)
+        Merger().merge(input, output, order)
 
     @app.command()
     def pdf2img(
         input: str = typer.Option(help="PDF file that you want to convert to image."),
-        output: str = typer.Option(help="Where you gonna find the extracted images.")
+        output: str = typer.Option(help="Where you gonna find the extracted images."),
     ):
         pdfToImage().run(input, output)

--- a/pdf_suite/merger.py
+++ b/pdf_suite/merger.py
@@ -4,11 +4,12 @@ import PyPDF2
 from termspark import print
 
 class Merger:
-    ORDER = [
-        # pdf files in order.
-    ]
+    order = []
 
-    def merge(self, input_directory, output_directory):
+    def merge(self, input_directory, output_directory, order):
+        if order:
+            self.order = order.split(',')
+
         pdf_files = self.__get_pdf_files(input_directory)
 
         if (len(pdf_files) == 0):
@@ -38,10 +39,10 @@ class Merger:
     def __get_pdf_files(self, input_directory):
         pdf_files = []
 
-        if (len(self.ORDER) == 0):
+        if (len(self.order) == 0):
             pdf_files = glob.glob(f"{input_directory}/*.pdf")
         else:
-            for file in self.ORDER:
+            for file in self.order:
                 if not file.endswith('.pdf'):
                     file = file + '.pdf'
 


### PR DESCRIPTION
### Files structure
```bash
.
|-- input
|   |-- file1.pdf
|   |-- file2.pdf
|   |-- file3.pdf
```

### Run
```bash
pdf_suite merge -i input -o output --order file1,file2,file3
```

### Result
`output.pdf` will contain all `file1.pdf`, `file2.pdf` and `file3.pdf` in order.

```bash
.
|-- input
|   |-- file1.pdf
|   |-- file2.pdf
|   |-- file3.pdf
|-- output
    |-- output.pdf
```