### PR TITLE
Fix zip content

### DIFF
--- a/pdf_suite/pdf2img.py
+++ b/pdf_suite/pdf2img.py
@@ -60,7 +60,7 @@ class pdfToImage:
             for image in os.listdir(self._output_folder):
                 if not '.zip' in image:
                     image_path = os.path.join(self._output_folder, image)
-                    zipf.write(image_path)
+                    zipf.write(image_path, arcname=os.path.basename(image_path))
 
         for file in os.listdir(self._output_folder):
             if not '.zip' in file:


### PR DESCRIPTION
Zip content had a lot of recursive full path directories to the main images we need. This PR fixes this by putting only the wanted images directly in the zip file without a lot of directories inside.